### PR TITLE
Add parsing of link headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- **Feature:** Parse link headers from response and put them under `:links`
+
 ### 0.4.0
 
 - **Feature:** Java 9/10 Compatibility

--- a/src/clj_http/lite/client.clj
+++ b/src/clj_http/lite/client.clj
@@ -4,6 +4,7 @@
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [clj-http.lite.core :as core]
+            [clj-http.lite.links :refer [wrap-links]]
             [clj-http.lite.util :as util])
   (:import (java.io InputStream File)
            (java.net URL UnknownHostException))
@@ -240,6 +241,7 @@
       wrap-content-type
       wrap-form-params
       wrap-method
+      wrap-links
       wrap-unknown-host))
 
 (def #^{:doc

--- a/src/clj_http/lite/links.clj
+++ b/src/clj_http/lite/links.clj
@@ -1,0 +1,67 @@
+(ns clj-http.lite.links
+  "Namespace dealing with HTTP link headers
+
+  Imported from https://github.com/dakrone/clj-http/blob/217393258e7863514debece4eb7b23a7a3fa8bd9/src/clj_http/links.clj")
+
+(def ^:private quoted-string
+  #"\"((?:[^\"]|\\\")*)\"")
+
+(def ^:private token
+  #"([^,\";]*)")
+
+(def ^:private link-param
+  (re-pattern (str "(\\w+)=(?:" quoted-string "|" token ")")))
+
+(def ^:private uri-reference
+  #"<([^>]*)>")
+
+(def ^:private link-value
+  (re-pattern (str uri-reference "((?:\\s*;\\s*" link-param ")*)")))
+
+(def ^:private link-header
+  (re-pattern (str "(?:\\s*(" link-value ")\\s*,?\\s*)")))
+
+(defn read-link-params [params]
+  (into {}
+        (for [[_ name quot tok] (re-seq link-param params)]
+          [(keyword name) (or quot tok)])))
+
+(defn read-link-value [value]
+  (let [[_ uri params] (re-matches link-value value)
+        param-map      (read-link-params params)]
+    [(keyword (:rel param-map))
+     (-> param-map
+         (assoc :href uri)
+         (dissoc :rel))]))
+
+(defn read-link-headers [header]
+  (->> (re-seq link-header header)
+       (map second)
+       (map read-link-value)
+       (into {})))
+
+(defn- links-response
+  [response]
+  (if-let [link-headers (get-in response [:headers "link"])]
+    (let [link-headers (if (coll? link-headers)
+                         link-headers
+                         [link-headers])]
+      (assoc response
+        :links
+        (into {} (map read-link-headers link-headers))))
+    response))
+
+(defn wrap-links
+  "Add a :links key to the response map that contains parsed Link headers. The
+  links will be represented as a map, with the 'rel' value being the key. The
+  URI is placed under the 'href' key, to mimic the HTML link element.
+
+  e.g. Link: <http://example.com/page2.html>; rel=next; title=\"Page 2\"
+  => {:links {:next {:href \"http://example.com/page2.html\"
+  :title \"Page 2\"}}}"
+  [client]
+  (fn
+    ([request]
+      (links-response (client request)))
+    ([request respond raise]
+      (client request #(respond (links-response %)) raise))))

--- a/test/clj_http/test/links_test.clj
+++ b/test/clj_http/test/links_test.clj
@@ -1,0 +1,39 @@
+(ns clj-http.test.links-test
+  "Imported from https://github.com/dakrone/clj-http/blob/217393258e7863514debece4eb7b23a7a3fa8bd9/test/clj_http/test/links_test.clj"
+  (:require [clj-http.lite.links :refer :all]
+            [clojure.test :refer :all]))
+
+(defn- link-handler [link-header]
+  (wrap-links (constantly {:headers {"link" link-header}})))
+
+(deftest test-wrap-links
+  (testing "absolute link"
+    (let [handler (link-handler "<http://example.com/page2.html>; rel=next")]
+      (is (= (:links (handler {}))
+             {:next {:href "http://example.com/page2.html"}}))))
+  (testing "relative link"
+    (let [handler (link-handler "</page2.html>;rel=next")]
+      (is (= (:links (handler {}))
+             {:next {:href "/page2.html"}}))))
+  (testing "extra params"
+    (let [handler (link-handler "</page2.html>; rel=next; title=\"Page 2\"")]
+      (is (= (:links (handler {}))
+             {:next {:href "/page2.html", :title "Page 2"}}))))
+  (testing "multiple headers"
+    (let [handler (link-handler "</p1>;rel=prev, </p3>;rel=next,</>;rel=home")]
+      (is (= (:links (handler {}))
+             {:prev {:href "/p1"}
+              :next {:href "/p3"}
+              :home {:href "/"}}))))
+  (testing "no :links key if no link headers"
+    (let [handler  (wrap-links (constantly {:headers {}}))
+          response (handler {})]
+      (is (not (contains? response :links))))))
+
+(deftest t-multiple-link-headers
+  (let [handler (link-handler ["<http://example.com/Zl_A>; rel=shorturl"
+                               "<http://example.com/foo.png>; rel=icon"])
+        resp (handler {})]
+    (is (= (:links resp)
+           {:shorturl {:href "http://example.com/Zl_A"}
+            :icon {:href "http://example.com/foo.png"}}))))


### PR DESCRIPTION
In https://github.com/whitepages/github-changelog/pull/72 we ran into a problem where [clj-http](https://github.com/dakrone/clj-http) is too heavy for our usecase but `clj-http-lite` doesn't support the parsing of link headers.

It appears to me that the original clj-http-lite project had been forked from clj-http before link parsing support was added to the latter.

It appears fairly light so I took the courage to suggest porting it to this project. Please let me know your thoughts wrt this.