### PR TITLE
Add type hints for GraalVM

### DIFF
--- a/src/clj_http/lite/util.clj
+++ b/src/clj_http/lite/util.clj
@@ -19,12 +19,13 @@
 (defn url-decode
   "Returns the form-url-decoded version of the given string, using either a
   specified encoding or UTF-8 by default."
-  [encoded & [encoding]]
-  (URLDecoder/decode encoded (or encoding "UTF-8")))
+  [^String encoded & [encoding]]
+  (let [^String encoding (or encoding "UTF-8")]
+    (URLDecoder/decode encoded encoding)))
 
 (defn url-encode
   "Returns an UTF-8 URL encoded version of the given string."
-  [unencoded]
+  [^String unencoded]
   (URLEncoder/encode unencoded "UTF-8"))
 
 (defmacro base64-encode


### PR DESCRIPTION
Hi

And thanks for a fine project!

When using clj-http-lite with GraalVM 19.3, I'm getting a strange stacktrace exception:

```
JVM Exception: #error {
 :cause java.net.URLEncoder
 :via
 [{:type java.lang.ClassNotFoundException
   :message java.net.URLEncoder
   :at [com.oracle.svm.core.hub.ClassForNameSupport forName ClassForNameSupport.java 60]}]
 :trace
 [[com.oracle.svm.core.hub.ClassForNameSupport forName ClassForNameSupport.java 60]
  [java.lang.Class forName DynamicHub.java 1197]
  [clojure.lang.RT classForName RT.java 2204]
  [clojure.lang.RT classForName RT.java 2213]
  [clj_http.lite.util$url_encode invokeStatic util.clj 28]
  [clj_http.lite.client$generate_query_string$fn__1889 invoke client.clj 150]
...
```

Adding these type hints solves this problem.

Would that be OK to include in the project?

Thanks
Kind regards