### PR TITLE
Update link to Clojars

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ A Clojure HTTP library similar to [clj-http](http://github.com/dakrone/clj-http)
 
 ## Installation
 
-`clj-http-lite` is available as a Maven artifact from [Clojars](http://clojars.org/clj-http-lite):
+`clj-http-lite` is available as a Maven artifact from [Clojars](https://clojars.org/org.martinklepsch/clj-http-lite):
 
 ```clojure
 [org.martinklepsch/clj-http-lite "0.4.3"]


### PR DESCRIPTION
The link to Clojars was pointing to `clj-http-lite/clj-http-lite` on Maven. Updated it to `org.martinklepsch/clj-http-lite` 🙂